### PR TITLE
Bugfix for single json object

### DIFF
--- a/flutter_lib/CHANGELOG.md
+++ b/flutter_lib/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.4
+- Bugfix for single json object
+- Added label
+- Added initial value
+
 ## 0.0.3
 - Switched service to [ZIPAPI](https://zip-api.eu/en/)
 - Updated dependencies

--- a/flutter_lib/lib/postal_code.dart
+++ b/flutter_lib/lib/postal_code.dart
@@ -11,6 +11,9 @@ class PostalCodeField extends StatelessWidget {
   /// Will be called when a [PostalCode] is selected
   final Function(PostalCode)? onSelected;
 
+  /// Label for the text field
+  final Text? label;
+
   /// Hint for the text field
   final String? hint;
 
@@ -21,6 +24,7 @@ class PostalCodeField extends StatelessWidget {
     Key? key,
     required this.countryCode,
     required this.onSelected,
+    this.label,
     this.hint,
     this.suffixIcon,
   }) : super(key: key);
@@ -80,6 +84,7 @@ class PostalCodeField extends StatelessWidget {
             controller: textEditingController,
             focusNode: focusNode,
             decoration: InputDecoration(
+              label: label,
               hintText: hint,
               counter: const SizedBox(),
               suffixIcon: suffixIcon,

--- a/flutter_lib/lib/postal_code.dart
+++ b/flutter_lib/lib/postal_code.dart
@@ -112,7 +112,13 @@ class _PostalCodeService {
       return [];
     }
 
-    final List items = jsonDecode(response.body);
+    dynamic parsedResponse = jsonDecode(response.body);
+    List items = [];
+    if (parsedResponse is List) {
+      items.addAll(parsedResponse);
+    } else if (parsedResponse is Map) {
+      items.add(parsedResponse);
+    }
 
     return items
         .map((item) {

--- a/flutter_lib/lib/postal_code.dart
+++ b/flutter_lib/lib/postal_code.dart
@@ -11,6 +11,9 @@ class PostalCodeField extends StatelessWidget {
   /// Will be called when a [PostalCode] is selected
   final Function(PostalCode)? onSelected;
 
+  /// Initial value for the text field
+  final TextEditingValue? initialValue;
+
   /// Label for the text field
   final Text? label;
 
@@ -24,6 +27,7 @@ class PostalCodeField extends StatelessWidget {
     Key? key,
     required this.countryCode,
     required this.onSelected,
+    this.initialValue,
     this.label,
     this.hint,
     this.suffixIcon,
@@ -35,6 +39,7 @@ class PostalCodeField extends StatelessWidget {
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) => Autocomplete<PostalCode>(
+        initialValue: initialValue,
         optionsBuilder: (textEditingValue) async {
           final query = textEditingValue.text;
           return query.length > 1

--- a/flutter_lib/pubspec.yaml
+++ b/flutter_lib/pubspec.yaml
@@ -2,7 +2,7 @@ name: postal_code
 description: Autocomplete field for postal codes in any country around the world
 repository: https://github.com/Lamorak/postal_code/tree/master/flutter_lib
 
-version: 0.0.3
+version: 0.0.4
 
 environment:
   sdk: '>=3.0.5 <4.0.0'


### PR DESCRIPTION
fixes #1 

if only 1 postal code is fetched in the response,
the returned jsonDecode in line 115 returns a Map (for single json object) and not a list of Maps.

also added label and initial value to PostalCodeField